### PR TITLE
OPS-475 - Enforce compatible java version like RHEL does.

### DIFF
--- a/tasks/java.yml
+++ b/tasks/java.yml
@@ -38,6 +38,21 @@
   apt: name={{ java }} state={{java_state}}
   when: ansible_os_family == 'Debian'
 
+- name: Get the installed java path
+  shell: "update-alternatives --display java | grep '^/' | awk '{print $1}' | grep java-8-openjdk"
+  become: yes
+  register: java_full_path
+  failed_when: False
+  changed_when: False
+  when: ansible_os_family == 'Debian'
+
+- name: correct java version selected
+  alternatives:
+    name: java
+    path: "{{ java_full_path.stdout }}"
+    link: /usr/bin/java
+  when: ansible_os_family == 'Debian' and java_full_path is defined
+
 - name: register open_jdk version
   shell: java -version 2>&1 | grep OpenJDK
   register: open_jdk


### PR DESCRIPTION
This PR fixes an oversight in java detection under Debian based systems. RHEL systems do a check for the correct JRE, so I copied that code and updated it to find the correct matcher.

ES 6.3.X has some specific JRE requirements, especially when logstash is also used.

This is related to https://github.com/medal-labs/ansible/pull/82